### PR TITLE
feat: add lobbying-tracker app spec

### DIFF
--- a/tofu/config/hosting/specs/lobbying-tracker.yaml
+++ b/tofu/config/hosting/specs/lobbying-tracker.yaml
@@ -1,0 +1,24 @@
+title: Lobbying Expense Tracker
+name: lobbying-tracker
+name_short: lob-track
+program: policy
+repo: codeforamerica/lobbying-tracker
+internal: true
+secrets:
+  ADMIN_EMAILS:
+    description: Comma-separated list of Okta email addresses with admin access (Reports + Staff Rates)
+    type: string
+services:
+  web:
+    health_check_path: /health
+    expose: 3000
+    public: true
+    ports:
+      - 3000
+    volumes:
+      data:
+        type: persistent
+        mount: /app/data
+    secrets:
+      ADMIN_EMAILS:
+        name: ADMIN_EMAILS

--- a/tofu/config/hosting/specs/lobbying-tracker.yaml
+++ b/tofu/config/hosting/specs/lobbying-tracker.yaml
@@ -2,7 +2,7 @@ title: Lobbying Expense Tracker
 name: lobbying-tracker
 name_short: lob-track
 program: policy
-repo: codeforamerica/lobbying-tracker
+repo: codeforamerica/sharedservices-lobbying-tracker
 internal: true
 secrets:
   ADMIN_EMAILS:


### PR DESCRIPTION
## What

Registers the lobbying expense tracker with SharedServices by adding `tofu/config/hosting/specs/lobbying-tracker.yaml`.

## App details

- **Repo:** https://github.com/codeforamerica/sharedservices-lobbying-tracker
- **Subdomain:** lobbying-tracker.services.cfa.codes
- **Runtime:** Node.js, no npm dependencies
- **Storage:** EFS persistent volume at `/app/data` (JSON file-based)
- **Auth:** Internal only — Okta SSO at the edge; admin features (Reports + Staff Rates) gated server-side via `ADMIN_EMAILS` secret

## What DevOps needs to do

1. Review and merge this PR
2. Enable ECS Exec on the task definition (needed for one-time seed data copy — see DEPLOYMENT.md in the app repo)
3. Grant the task role `ssmmessages:*` for ECS Exec
4. Configure `ADMIN_EMAILS` secret in Doppler (comma-separated Okta emails for admin access)
5. Configure GitHub secrets for the deploy workflow — Doppler manages `DEPLOYMENT_APP_ID` and `DEPLOYMENT_APP_KEY`
6. Confirm the health check passes and hand back the URL

## Open questions for DevOps

- **Deploy workflow template:** What's the standard GitHub Actions workflow for ECR build + ECS deploy? (RFC TODO-8)
- **SSO identity header:** What header does the edge layer inject after Okta auth? (`x-forwarded-user` is the current placeholder — depends on ALB vs CloudFront+Lambda decision, RFC TODO-6)

## References

- [DEPLOYMENT.md](https://github.com/codeforamerica/sharedservices-lobbying-tracker/blob/main/DEPLOYMENT.md) in the app repo covers the full onboarding flow
- RFC: Internal Tools Platform (distributed in Slack)